### PR TITLE
Only add commas between array elements when needed

### DIFF
--- a/Json5/Json5Array.cs
+++ b/Json5/Json5Array.cs
@@ -115,10 +115,24 @@ namespace Json5
         {
             string newLine = string.IsNullOrEmpty(space) ? "" : "\n";
 
+            // TODO: Use string builder instead of string
             string s = "[" + newLine;
 
+            bool isFirstValue = true;
+
             foreach (Json5Value value in this)
-                s += (value ?? Null).ToJson5String(space, indent + space) + "," + newLine;
+            {
+                if (isFirstValue)
+                {
+                    isFirstValue = false;
+                }
+                else
+                {
+                    s += "," + newLine;
+                }
+
+                s += (value ?? Null).ToJson5String(space, indent + space);
+            }
 
             s += indent + "]";
 


### PR DESCRIPTION
Old behavior:
**[1,** _->_ **[1,2,** etc.
New behavior:
**[1** _->_ **[1,2** etc.

This fixes at least following tests: 
**ArrayValuesTest
MultipleArrayValuesTest
NestedArraysTest
EmptyStringSpaceTest**