### PR TITLE
Change parsing of hex numbers

### DIFF
--- a/Json5/Parsing/Json5Lexer.cs
+++ b/Json5/Parsing/Json5Lexer.cs
@@ -558,7 +558,8 @@ namespace Json5.Parsing
                     }
 
                     // Parse this value with BigInteger because ulong can only parse numbers up to 0xFFFFFFFFFFFFFFFF.
-                    return Token(Json5TokenType.Number, sign * (double)BigInteger.Parse(valueBuffer, NumberStyles.HexNumber), inputBuffer);
+                    // Add '0' to valueBuffer since otherwise it will be parsed as signed value (e.g. ff would be -1) 
+                    return Token(Json5TokenType.Number, sign * (double)BigInteger.Parse("0" + valueBuffer, NumberStyles.HexNumber), inputBuffer);
 
                 case State.String:
                     switch (r)


### PR DESCRIPTION
This makes HexadecimalNumbersTest pass. The reasoning for additional '0' can be found from https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger.parse?redirectedfrom=MSDN&view=netframework-4.7.2#System_Numerics_BigInteger_Parse_System_String_System_Globalization_NumberStyles_