### PR TITLE
Remove unneeded spaces and commas from Json5Object.ToJson5String

### DIFF
--- a/Json5/Json5Object.cs
+++ b/Json5/Json5Object.cs
@@ -69,12 +69,24 @@ namespace Json5
         {
             string newLine = string.IsNullOrEmpty(space) ? "" : "\n";
 
+            // TODO: Use string builder instead of string
             string s = "{" + newLine;
+
+            bool isFirstValue = true;
 
             foreach (var property in this)
             {
-                s += indent + space + KeyToString(property.Key) + ": ";
-                s += (property.Value ?? Null).ToJson5String(space, indent + space) + "," + newLine;
+                if (isFirstValue)
+                {
+                    isFirstValue = false;
+                }
+                else
+                {
+                    s += "," + newLine;
+                }
+
+                s += indent + space + KeyToString(property.Key) + ":";
+                s += (property.Value ?? Null).ToJson5String(space, indent + space);
             }
 
             s += indent + "}";


### PR DESCRIPTION
This fixes at least following tests:
**UnquotedPropertyNamesTest
EmptyStringPropertyNamesTest
SpecialCharacterPropertyNamesTest
UnicodePropertyNamesTest
MultiplePropertiesTest
NestedObjectsTest**