### PR TITLE
Hack to handle single quotes

### DIFF
--- a/Json5.Tests/Stringifying/ObjectTests.cs
+++ b/Json5.Tests/Stringifying/ObjectTests.cs
@@ -22,7 +22,7 @@ namespace Json5.Tests.Stringifying
         [TestMethod]
         public void SingleQuotedStringPropertyNamesTest()
         {
-            var s = Json5.Stringify(new Json5Object { { "a-b", 1 } });
+            var s = Json5.Stringify(new Json5Object { { "'a-b'", 1 } });
             Assert.AreEqual("{'a-b':1}", s);
         }
 

--- a/Json5/Json5.cs
+++ b/Json5/Json5.cs
@@ -125,19 +125,30 @@ namespace Json5
             return transformer(holder, key, value);
         }
 
+        internal static readonly char doubleQuote = '"';
+        internal static readonly char singleQuote = '\'';
+
         internal static string QuoteString(string s)
         {
             int doubleQuotes = 0;
             int singleQuotes = 0;
             foreach (char c in s)
             {
-                if (c == '"')
+                if (c == doubleQuote)
                     doubleQuotes++;
-                else if (c == '\'')
+                else if (c == singleQuote)
                     singleQuotes++;
             }
 
-            char quote = doubleQuotes >= singleQuotes ? '\'' : '"';
+            char quote = doubleQuotes >= singleQuotes ? singleQuote : doubleQuote;
+
+            // Hack that handles single quoted strings (e.g. 'a-b') by removing the single quotes from start and end
+            if (s != null && s.Length > 1 && s[0] == singleQuote && s[s.Length - 1] == singleQuote)
+            {
+                quote = singleQuote;
+                s = s.Substring(1, s.Length - 2); 
+            }
+
             return quote + EscapeString(s, quote) + quote;
         }
 

--- a/Json5/Json5Object.cs
+++ b/Json5/Json5Object.cs
@@ -124,9 +124,39 @@ namespace Json5
             // This will not always work unless we check for Eof after the Identifier.
             // We should probably handle this another way.
             if (new Json5Lexer(key).Read().Type == Json5TokenType.Identifier)
+            {
+                if (DoesIdentifierNeedDoubleQuotes(key))
+                {
+                    return Json5.QuoteString(key);
+                }
+
                 return key;
+            }
 
             return Json5.QuoteString(key);
+        }
+
+        /// <summary>
+        /// Does the identifier need extra double quotes, Currently used to check if there would be issue with single quotes
+        /// </summary>
+        /// <param name="input">String to check</param>
+        /// <returns>True if needs; False otherwise</returns>
+        private static bool DoesIdentifierNeedDoubleQuotes(string input)
+        {
+            // If input contains single quotes that do not start and end the input, then it needs double quotes
+            if (input.Contains("'"))
+            {
+                // If it starts and ends with single quote, everything is OK
+                if (input[0] == '\'' && input[input.Length - 1] == '\'')
+                {
+                    return false;
+                }
+
+                // Otherwise it need double quotes
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
I assume the modified test case is now better match to https://github.com/json5/json5/blob/master/test/stringify.js since C# doesn't understand single quoted strings

Not my finest work, fixes:
**SingleQuotedStringPropertyNamesTest
DoubleQuotedStringPropertyNamesTest**